### PR TITLE
Remove fds lib installation and add run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: http://software.igwn.org/sources/source/Xform-{{ version }}.tar.gz
-  sha256: 9a49ddf0efdb4490245297c61955c8d8a08d5f915244f5a730e9e66f439e77c0
+  sha256: b2f0ffd29d1f8cea10c6c35749fd481acffd6e57a20db54d218caff69ea623a8
 
 build:
   number: 1
@@ -43,7 +43,6 @@ test:
     - pkg-config
   commands:
     - test -x ${PREFIX}/bin/fdesign  # [unix]
-    - test -f ${PREFIX}/lib/libfds.so  # [unix]
     - test -f ${PREFIX}/lib/libforms.so  # [unix]
     - pkg-config --print-errors --modversion xforms
      

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9a49ddf0efdb4490245297c61955c8d8a08d5f915244f5a730e9e66f439e77c0
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not linux]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   sha256: b2f0ffd29d1f8cea10c6c35749fd481acffd6e57a20db54d218caff69ea623a8
 
 build:
+  run_exports:
+    - {{ pin_subpackage("xforms", max_pin="x") }}
   number: 1
   skip: True  # [not linux]
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The libfds is not designed to be used by other users and is only meant to be used by fdesign executable. This has also been changed to a static library (as done by the original package), this then stops any undefined reference error occurring. This pull request also adds run_exports to the build to pin major package releases.